### PR TITLE
Ecommerce tracking with App Settings

### DIFF
--- a/app/views/pages/thank_you.html.erb
+++ b/app/views/pages/thank_you.html.erb
@@ -8,14 +8,14 @@
       ga('ecommerce:addTransaction', {
         'id': "<%= user.stripe_customer_id %>",
         'affiliation': 'EmberScreencasts',
-        'revenue': '9.99'
+        'revenue': '9.95'
       });
       ga('ecommerce:addItem', {
         'id': "<%= user.stripe_customer_id %>",
         'name': 'Monthly Pro Subscriber',
         'sku': 'pro_2',
         'category': 'Subscriptions',
-        'price': '9.99',
+        'price': '9.95',
         'quantity': '1'
       });
       ga('ecommerce:send');

--- a/app/views/pages/thank_you.html.erb
+++ b/app/views/pages/thank_you.html.erb
@@ -1,3 +1,28 @@
+<% if ENV['RENDER_ANALYTICS'] == true %>
+  <%
+    user = current_user
+  %>
+  <% content_for :scripts do %>
+    <script>
+      ga('require', 'ecommerce');
+      ga('ecommerce:addTransaction', {
+        'id': "<%= user.stripe_customer_id %>",
+        'affiliation': 'EmberScreencasts',
+        'revenue': '9.99'
+      });
+      ga('ecommerce:addItem', {
+        'id': "<%= user.stripe_customer_id %>",
+        'name': 'Monthly Pro Subscriber',
+        'sku': 'pro_2',
+        'category': 'Subscriptions',
+        'price': '9.99',
+        'quantity': '1'
+      });
+      ga('ecommerce:send');
+    </script>
+  <% end %>
+<% end %>
+
 <div class="container">
   <h1>Thank You!</h1>
   <h4>You can now view every screencast on the site.</h4>

--- a/app/views/shared/_script_footer.html.erb
+++ b/app/views/shared/_script_footer.html.erb
@@ -1,2 +1,5 @@
-<%= render 'shared/snippets/analytics' if ENV['RENDER_ANALYTICS'] %>
-<%= render 'shared/snippets/optimizations' if ENV['RENDER_OPTIMIZATIONS'] %>
+<%= render 'shared/snippets/analytics' if ENV['RENDER_ANALYTICS'] == true %>
+<%= render 'shared/snippets/optimizations' if ENV['RENDER_OPTIMIZATIONS'] == true %>
+<% if content_for?(:scripts) %>
+  <%= yield(:scripts) %>
+<% end %>

--- a/app/views/shared/snippets/_analytics.html.erb
+++ b/app/views/shared/snippets/_analytics.html.erb
@@ -13,7 +13,7 @@ _kms('//i.kissmetrics.com/i.js');
 _kms('//doug1izaerwt3.cloudfront.net/' + _kmk + '.1.js');
 </script>
 
-<!-- Google Analytics tracking snippet -->
+<!-- Google analytics.js tracking snippet -->
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Closes #15

-use analytics.js ecommerce library to send transaction data to Google Analytics 
https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce#overview
- [x] Need to enable E-commerce tracking within Google Analytics. Requires admin permission: 
  <img width="970" alt="screenshot 2016-03-15 11 08 22" src="https://cloud.githubusercontent.com/assets/3036915/14397731/dea1f1ae-fda4-11e5-93a2-327f6e79b92d.png">

Time total so far: 1 hr
